### PR TITLE
Add support for serving utxo states

### DIFF
--- a/src/handlers/common.rs
+++ b/src/handlers/common.rs
@@ -1,5 +1,7 @@
-
 use cardano::block::EpochId;
+use router::{Router};
+use iron::{Request};
+use super::super::config::{Networks, Network};
 
 pub fn validate_network_name(v: &&str) -> bool {
     v.chars().all(|c| c.is_ascii_alphanumeric())
@@ -11,4 +13,27 @@ pub fn validate_epochid(v: &&str) -> Option<EpochId> {
     } else {
         Some(v.parse::<EpochId>().unwrap())
     }
+}
+
+pub fn get_network_and_epoch<'a>(req: &Request, networks: &'a Networks) -> Option<(&'a Network, EpochId)> {
+    let ref network_name = req.extensions.get::<Router>().unwrap().find("network").unwrap();
+    let ref epochid_str = req.extensions.get::<Router>().unwrap().find("epochid").unwrap();
+
+    if ! validate_network_name (network_name) {
+        return None;
+    }
+    let net = match networks.get(network_name.to_owned()) {
+        None => return None,
+        Some(net) => net
+    };
+
+    let epochid = match validate_epochid (epochid_str) {
+        None => {
+            error!("invalid epochid: {}", epochid_str);
+            return None;
+        },
+        Some(e) => e,
+    };
+
+    Some((net, epochid))
 }

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -3,3 +3,5 @@ pub mod block;
 pub mod pack;
 pub mod epoch;
 pub mod tip;
+pub mod utxos;
+pub mod utxos_delta;

--- a/src/handlers/utxos.rs
+++ b/src/handlers/utxos.rs
@@ -1,4 +1,4 @@
-use cardano_storage::{epoch};
+use cardano_storage::utxo;
 
 use std::sync::{Arc};
 
@@ -21,26 +21,28 @@ impl Handler {
         }
     }
     pub fn route(self, router: &mut Router) -> &mut Router {
-        router.get(":network/epoch/:epochid", self, "epoch")
+        router.get(":network/utxos/:epochid", self, "utxos")
     }
 }
 
 impl iron::Handler for Handler {
     fn handle(&self, req: &mut Request) -> IronResult<Response> {
+
         let (net, epochid) = match common::get_network_and_epoch(req, &self.networks) {
             None => { return Ok(Response::with(status::BadRequest)); }
             Some(x) => x
         };
 
-        let opackref = epoch::epoch_read_pack(&net.storage.config, epochid);
-        match opackref {
-            Err(_) => {
-                return Ok(Response::with(status::NotFound));
-            },
-            Ok(packref) => {
-                let path = net.storage.config.get_pack_filepath(&packref);
-                Ok(Response::with((status::Ok, path)))
-            },
-        }
+        let mut res = vec![];
+
+        let utxo_state = utxo::get_utxos_for_epoch(&net.storage, epochid).unwrap();
+
+        utxo::write_utxos_delta(&net.storage,
+                                &utxo_state.last_block,
+                                &utxo_state.last_date,
+                                &utxo_state.utxos,
+                                None, &mut res).unwrap();
+
+        Ok(Response::with((status::Ok, res)))
     }
 }

--- a/src/handlers/utxos_delta.rs
+++ b/src/handlers/utxos_delta.rs
@@ -1,0 +1,51 @@
+use cardano_storage::utxo;
+
+use std::sync::{Arc};
+
+use iron;
+use iron::{Request, Response, IronResult};
+use iron::status;
+
+use router::{Router};
+
+use super::super::config::{Networks};
+use super::common;
+
+pub struct Handler {
+    networks: Arc<Networks>
+}
+impl Handler {
+    pub fn new(networks: Arc<Networks>) -> Self {
+        Handler {
+            networks: networks
+        }
+    }
+    pub fn route(self, router: &mut Router) -> &mut Router {
+        router.get(":network/utxos-delta/:epochid/:to", self, "utxos-delta")
+    }
+}
+
+impl iron::Handler for Handler {
+    fn handle(&self, req: &mut Request) -> IronResult<Response> {
+
+        let (net, from) = match common::get_network_and_epoch(req, &self.networks) {
+            None => { return Ok(Response::with(status::BadRequest)); }
+            Some(x) => x
+        };
+
+        let to = common::validate_epochid(
+            &req.extensions.get::<Router>().unwrap().find("to").unwrap()).unwrap();
+
+        let mut res = vec![];
+
+        let to_state = utxo::get_utxos_for_epoch(&net.storage, to).unwrap();
+
+        utxo::write_utxos_delta(&net.storage,
+                                &to_state.last_block,
+                                &to_state.last_date,
+                                &to_state.utxos,
+                                Some(from), &mut res).unwrap();
+
+        Ok(Response::with((status::Ok, res)))
+    }
+}

--- a/src/service.rs
+++ b/src/service.rs
@@ -22,6 +22,8 @@ fn start_http_server(cfg: &Config, networks: Arc<Networks>) -> iron::Listening {
     handlers::pack::Handler::new(networks.clone()).route(&mut router);
     handlers::epoch::Handler::new(networks.clone()).route(&mut router);
     handlers::tip::Handler::new(networks.clone()).route(&mut router);
+    handlers::utxos::Handler::new(networks.clone()).route(&mut router);
+    handlers::utxos_delta::Handler::new(networks.clone()).route(&mut router);
     info!("listening to port {}", cfg.port);
     iron::Iron::new(router)
         .http(format!("0.0.0.0:{}", cfg.port))

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,5 +1,5 @@
 use super::config::{Config, Networks, Network};
-use exe_common::sync;
+use exe_common::{sync, parse_genesis_data, genesis_data};
 use super::handlers;
 use iron;
 use router::Router;
@@ -55,6 +55,13 @@ fn refresh_network(label: &str, net: &Network) {
     let netcfg_file = net.storage.config.get_config_file();
     let net_cfg = net::Config::from_file(&netcfg_file).expect("no network config present");
 
-    sync::net_sync(&mut sync::get_peer(&label, &net_cfg, true), &net_cfg, &net.storage, false)
+    let genesis_data = {
+        let genesis_data = genesis_data::get_genesis_data(&net_cfg.genesis_prev)
+            .expect("genesis data not found");
+        parse_genesis_data::parse_genesis_data(genesis_data)
+    };
+
+    sync::net_sync(&mut sync::get_peer(&label, &net_cfg, true), &net_cfg,
+                   &genesis_data, &net.storage, false)
         .unwrap_or_else(|err| { warn!("Sync failed: {:?}", err) });
 }


### PR DESCRIPTION
For example,
    
    http://localhost:12080/mainnet/utxos/54
    
gives a file containing the full utxo state at the end of epoch 54, while
    
    http://localhost:12080/mainnet/utxos-delta/53/54
    
gives a file containing the delta between the end of epoch 53 and the end of epoch 54.
