### PR TITLE
Txsend implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.1"
 authors = [ "Nicolas Di Prima <nicolas.diprima@iohk.io>"
           , "Vincent Hanquez <vincent.hanquez@iohk.io>"
           ]
+edition = "2018"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/input-output-hk/cardano-http-bridge"
 homepage = "https://github.com/input-output-hk/cardano-http-bridge#README.md"
@@ -22,11 +23,14 @@ exe-common      = { path = "cardano-deps/exe-common" }
 
 serde = "1.0"
 serde_derive = "1.0"
+serde_json = "1.0"
 serde_yaml = "0.7"
 log = "0.4"
 env_logger = "0.5.9"
 iron = "*"
 router ="*"
+base64 = "0.9"
+cbor_event = "1.0"
 
 [dependencies.clap]
 version = "2.31"

--- a/src/handlers/common.rs
+++ b/src/handlers/common.rs
@@ -15,17 +15,22 @@ pub fn validate_epochid(v: &&str) -> Option<EpochId> {
     }
 }
 
-pub fn get_network_and_epoch<'a>(req: &Request, networks: &'a Networks) -> Option<(&'a Network, EpochId)> {
+pub fn get_network<'a>(req: &Request, networks : &'a Networks) -> Option<(String, &'a Network)> {
     let ref network_name = req.extensions.get::<Router>().unwrap().find("network").unwrap();
-    let ref epochid_str = req.extensions.get::<Router>().unwrap().find("epochid").unwrap();
 
     if ! validate_network_name (network_name) {
         return None;
     }
-    let net = match networks.get(network_name.to_owned()) {
-        None => return None,
-        Some(net) => net
-    };
+    
+    match networks.get(network_name.to_owned()) {
+        None => None,
+        Some(net) => Some((network_name.to_string(), net))
+    }
+}
+
+pub fn get_network_and_epoch<'a>(req: &Request, networks: &'a Networks) -> Option<(&'a Network, EpochId)> {
+    let (_, net) = get_network(req, networks)?;
+    let ref epochid_str = req.extensions.get::<Router>().unwrap().find("epochid").unwrap();
 
     let epochid = match validate_epochid (epochid_str) {
         None => {

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -3,5 +3,6 @@ pub mod block;
 pub mod pack;
 pub mod epoch;
 pub mod tip;
+pub mod tx;
 pub mod utxos;
 pub mod utxos_delta;

--- a/src/handlers/tx.rs
+++ b/src/handlers/tx.rs
@@ -1,0 +1,69 @@
+use cardano::{tx::TxAux};
+
+use std::{io::Read, sync::Arc};
+
+use iron;
+use iron::{Request, Response, IronResult};
+use iron::status;
+
+use router::{Router};
+
+use serde_json;
+
+use super::super::config::{Networks};
+use super::common;
+use exe_common::{config::net, network::Api, sync};
+
+pub struct Handler {
+    networks: Arc<Networks>
+}
+impl Handler {
+    pub fn new(networks: Arc<Networks>) -> Self {
+        Handler {
+            networks: networks
+        }
+    }
+    pub fn route(self, router: &mut Router) -> &mut Router {
+        router.post(":network/txs/signed", self, "txs_signed_send")
+    }
+}
+
+impl iron::Handler for Handler {
+    fn handle(&self, req: &mut Request) -> IronResult<Response> {
+        fn read_txaux_from_req_str(tx_str: &str) -> Option<TxAux> {
+            let json = serde_json::from_str::<serde_json::Value>(tx_str).ok()?;
+            let base_64 = json.
+                as_object()?.
+                get("signedTx")?.
+                as_str()?.clone();
+            let bytes = base64::decode(&base_64).ok()?;
+            cbor_event::de::RawCbor::from(&bytes).deserialize_complete().ok()
+        }
+        let mut req_body_str = String::new();
+        req.body.read_to_string(&mut req_body_str).unwrap();
+        let txaux = match read_txaux_from_req_str(req_body_str.as_str()) {
+            None => { return Ok(Response::with(status::BadRequest)); }
+            Some(x) => x
+        };
+
+        println!("Received a valid txauth to send:\n{:?}", txaux);
+
+        let (net_name, net) = match common::get_network(req, &self.networks) {
+            None => { return Ok(Response::with(status::BadRequest)); }
+            Some(x) => x
+        };
+
+        let netcfg_file = net.storage.config.get_config_file();
+        let net_cfg = net::Config::from_file(&netcfg_file).expect("no network config present");
+        let mut peer = sync::get_peer(&net_name, &net_cfg, true);
+
+        println!("found a peer to send from!");
+
+        // match peer.send_transaction(txaux) {
+        //     Err(_) => return Ok(Response::with(status::InternalServerError)),
+        //     Ok(value) => assert!(value)
+        // };
+
+        Ok(Response::with((status::Ok, "Transaction sent successfully!")))
+    }
+}

--- a/src/service.rs
+++ b/src/service.rs
@@ -22,6 +22,7 @@ fn start_http_server(cfg: &Config, networks: Arc<Networks>) -> iron::Listening {
     handlers::pack::Handler::new(networks.clone()).route(&mut router);
     handlers::epoch::Handler::new(networks.clone()).route(&mut router);
     handlers::tip::Handler::new(networks.clone()).route(&mut router);
+    handlers::tx::Handler::new(networks.clone()).route(&mut router);
     handlers::utxos::Handler::new(networks.clone()).route(&mut router);
     handlers::utxos_delta::Handler::new(networks.clone()).route(&mut router);
     info!("listening to port {}", cfg.port);


### PR DESCRIPTION
Implemented the ability to TxAuxs too all native relay nodes.
Receives via a POST request to <network>/txs/signed where <network> is the network to send to.
Simply relays the responsibility to the first native node found.