### PR TITLE
Fix storage concurrency bug.

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -139,6 +139,7 @@ impl Config {
     }
 }
 
+#[derive(Clone)]
 pub struct Network {
     pub path: PathBuf,
     pub config: net::Config,


### PR DESCRIPTION
Previously two Storage copies were held - one by the handlers and the
other by the network refresh thread. This led to desync between them as
the handlers could not access any new data synced during the current
run.