### PR TITLE
Allow passing a custom file as a template configuration

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,10 @@ extern crate cardano;
 extern crate cardano_storage;
 extern crate exe_common;
 
-use std::path::PathBuf;
+use std::path::{
+    PathBuf,
+    Path,
+};
 
 mod config;
 mod handlers;
@@ -63,7 +66,6 @@ fn main() {
                         .required(false)
                         .multiple(true)
                         .default_value("mainnet")
-                        .possible_values(&["mainnet", "staging", "testnet"]),
                 )
                 .arg(
                     Arg::with_name("no-sync")
@@ -97,11 +99,12 @@ fn main() {
                     "mainnet" => net::Config::mainnet(),
                     "staging" => net::Config::staging(),
                     "testnet" => net::Config::testnet(),
-                    _ => {
-                        // we do not support custom template yet.
-                        // in the mean while the error is handled by clap
-                        // (possible_values)
-                        panic!("unknown template '{}'", template)
+                    filepath  => {
+                        let path = Path::new(filepath);
+                        match net::Config::from_file(path) {
+                            None => panic!("unknown or missing template '{}'", template),
+                            Some(cfg) => cfg,
+                        }
                     }
                 };
 


### PR DESCRIPTION
This allows for passing a custom configuration from a yaml file
with the following format:

```yaml
genesis: 89D9B5A5B8DDC8D7E5A6795E9774D97FAF1EFEA59B2CAF7EAF9F8C5B32059DF4
genesis_prev: 5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb
epoch_stability_depth: 2160
protocol_magic: 764824073
epoch_start: 0
peers:
  - iohk-hosts: relays.cardano-mainnet.iohk.io:3000
  - hermes: http://hermes.dev.iohkdev.io/mainnet
```

where every peer could be in theory any relay nodes; This would enable
connecting the http-bridge to a local cluster of node in order to
perform various task of integration testing.