### PR TITLE
[IOHKCRB-18] Create endpoint to retrieve utxos

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,31 @@ disseminated to the different nodes it knows of:
 
 The body of the request is the base64 encoded signed transaction.
 
+## GET: `/:network/utxos/:address`
+
+Allows you to query utxos in JSON format given:
+
+* `:network` is any of the network passed to the `--template` options at startup.
+* `:address` base58 encoding of an address
+
+Example query:
+
+```
+curl http://localhost:8080/mainnet/utxos/2cWKMJemoBamE3kYCuVLq6pwWwNBJVZmv471Zcb2ok8cH9NjJC4JUkq5rV5ss9ALXWCKN
+```
+
+Possible response:
+```json
+[
+    {
+        "address": "2cWKMJemoBamE3kYCuVLq6pwWwNBJVZmv471Zcb2ok8cH9NjJC4JUkq5rV5ss9ALXWCKN",
+        "coin": 310025,
+        "index": 0,
+        "txid": "89eb0d6a8a691dae2cd15ed0369931ce0a949ecafa5c3f93f8121833646e15c3"
+    }
+]
+```
+
 ## GET: `/:network/chain-state/:epochid`
 
 ## GET: `/:network/chain-state-delta/:epochid/:to`

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -7,3 +7,4 @@ pub mod genesis;
 pub mod pack;
 pub mod tip;
 pub mod tx;
+pub mod utxos;

--- a/src/handlers/utxos.rs
+++ b/src/handlers/utxos.rs
@@ -1,0 +1,175 @@
+use cardano_storage::{chain_state, tag, Error};
+use exe_common::network::BlockRef;
+use exe_common::{genesisdata, sync};
+
+use std::sync::Arc;
+
+use iron;
+use iron::status;
+use iron::{IronResult, Request, Response};
+
+use router::Router;
+
+use super::super::config::Networks;
+use super::common;
+
+use std::str::FromStr;
+
+pub struct Handler {
+    networks: Arc<Networks>,
+}
+impl Handler {
+    pub fn new(networks: Arc<Networks>) -> Self {
+        Handler { networks: networks }
+    }
+    pub fn route(self, router: &mut Router) -> &mut Router {
+        router.get(":network/utxos/:address", self, "utxos")
+    }
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
+struct Utxo {
+    txid: cardano::tx::TxId,
+    index: u32,
+    address: cardano::address::ExtendedAddr,
+    coin: cardano::coin::Coin,
+}
+
+impl iron::Handler for Handler {
+    fn handle(&self, req: &mut Request) -> IronResult<Response> {
+        let (_, net) = match common::get_network(req, &self.networks) {
+            None => {
+                return Ok(Response::with(status::BadRequest));
+            }
+            Some(x) => x,
+        };
+
+        let params = req.extensions.get::<router::Router>().unwrap();
+        let address = params.find("address").unwrap();
+
+        let genesis_str = genesisdata::data::get_genesis_data(&net.config.genesis_prev).unwrap();
+        let genesis_data = genesisdata::parse::parse(genesis_str.as_bytes());
+
+        let storage = net.storage.read().unwrap();
+
+        let tip = match net.storage.read().unwrap().get_block_from_tag(&tag::HEAD) {
+            Err(Error::NoSuchTag) => {
+                return Ok(Response::with((status::NotFound, "No Tip To Serve")));
+            }
+            Err(err) => {
+                error!("error while reading block: {:?}", err);
+                return Ok(Response::with(status::InternalServerError));
+            }
+            Ok(block) => {
+                let header = block.header();
+                BlockRef {
+                    hash: header.compute_hash(),
+                    parent: header.previous_header(),
+                    date: header.blockdate(),
+                }
+            }
+        };
+
+        let chain_state =
+            chain_state::restore_chain_state(&storage, &genesis_data, &tip.hash).unwrap();
+
+        let filter_address = match cardano::address::ExtendedAddr::from_str(&address) {
+            Ok(addr) => addr,
+            Err(_) => return Ok(Response::with((status::BadRequest, "Invalid address"))),
+        };
+
+        let utxos = utxos_by_address(&chain_state.utxos, &filter_address);
+
+        let serialized_data = serde_json::to_string(&utxos).unwrap();
+
+        let mut response = Response::with((status::Ok, serialized_data));
+        response.headers.set(iron::headers::ContentType::json());
+
+        Ok(response)
+    }
+}
+
+fn utxos_by_address(
+    utxos: &cardano::block::Utxos,
+    address: &cardano::address::ExtendedAddr,
+) -> Vec<Utxo> {
+    utxos
+        .iter()
+        .filter_map(|(k, v)| {
+            if v.address == *address {
+                Some(Utxo {
+                    txid: k.id,
+                    index: k.index,
+                    address: v.address.clone(),
+                    coin: v.value,
+                })
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use cardano::address::ExtendedAddr;
+    use cardano::tx::TxOut;
+    use cardano::tx::TxoPointer;
+    use std::collections::BTreeMap;
+
+    static BASE58_ADDRESS : &str = "DdzFFzCqrhsjcfsReoiHddtt3ih6YusHbNXMTAjCvi5vakqk6sHkXDbMkaYgAbZyiy6hNK4761cF33AaCog93vbwgXGEXKgmA52dhrhJ";
+    static BYTES : [u8; 32] = [0u8; 32];
+
+    #[test]
+    fn filter_existent_address() {
+        let mut utxos = BTreeMap::<TxoPointer, TxOut>::new();
+
+        let filter_address = ExtendedAddr::from_str(&BASE58_ADDRESS).unwrap();
+        let txid = cardano::hash::Blake2b256::new(&BYTES);
+
+        utxos.insert(
+            TxoPointer { id: txid, index: 0 },
+            TxOut {
+                address: filter_address.clone(),
+                value: cardano::coin::Coin::new(1000).unwrap(),
+            },
+        );
+
+        let res = utxos_by_address(&utxos, &filter_address);
+        assert!(res.contains(&Utxo {
+            txid: txid,
+            index: 0,
+            address: ExtendedAddr::from_str(&BASE58_ADDRESS).unwrap(),
+            coin: cardano::coin::Coin::new(1000).unwrap(),
+        }));
+    }
+
+    #[test]
+    fn filter_inexistent_address() {
+        let mut utxos = BTreeMap::<TxoPointer, TxOut>::new();
+
+        let filter_address = ExtendedAddr::from_str(&BASE58_ADDRESS).unwrap();
+
+        let txid = cardano::hash::Blake2b256::new(&BYTES);
+
+        let different_address = "DdzFFzCqrhtD4c7dNAyVG29R64GapneLWUbVTECYywUsc6baB7FatGkTGcLWNj3hZnhXJ1ZD43ZBooiUVnVEGQSmEjrxdAP7YUk8dQze";
+        utxos.insert(
+            TxoPointer { id: txid, index: 1 },
+            TxOut {
+                address: ExtendedAddr::from_str(&different_address).unwrap(),
+                value: cardano::coin::Coin::new(1000).unwrap(),
+            },
+        );
+
+        let res = utxos_by_address(&utxos, &filter_address);
+
+        assert!(!res.contains(&Utxo {
+            txid: txid,
+            index: 0,
+            address: ExtendedAddr::from_str(&BASE58_ADDRESS).unwrap(),
+            coin: cardano::coin::Coin::new(1000).unwrap(),
+        }));
+    }
+}

--- a/src/service.rs
+++ b/src/service.rs
@@ -34,6 +34,7 @@ fn start_http_server(cfg: &Config, networks: Arc<Networks>) -> iron::Listening {
     handlers::tx::Handler::new(networks.clone()).route(&mut router);
     handlers::chain_state::Handler::new(networks.clone()).route(&mut router);
     handlers::chain_state_delta::Handler::new(networks.clone()).route(&mut router);
+    handlers::utxos::Handler::new(networks.clone()).route(&mut router);
     info!("listening to port {}", cfg.port);
     iron::Iron::new(router)
         .http(format!("0.0.0.0:{}", cfg.port))


### PR DESCRIPTION
---
name: [IOHKCRB-18] Create endpoint to retrieve utxos
about: ^

---

# Description
Add **`/:network/utxos/:address`** endpoint to get utxos by address in JSON.

At this point, the chain state is reconstructed linearly from the last stable epoch with the function `chain_state::restore_chain_state`.

The result is a list of utxos, example:
```json
[
    {
        "address": "2cWKMJemoBamE3kYCuVLq6pwWwNBJVZmv471Zcb2ok8cH9NjJC4JUkq5rV5ss9ALXWCKN",
        "coin": 310025,
        "index": 0,
        "txid": "89eb0d6a8a691dae2cd15ed0369931ce0a949ecafa5c3f93f8121833646e15c3"
    }
]
```

# TODO
 - As restoring the chain state at every request is too slow,  the next step is to implement some way of keeping the utxos in memory, by using the `ChainState` struct and the [verify_block](https://github.com/input-output-hk/rust-cardano/blob/c557ba21fda2f3496e34ed74652bbe9dd701319b/cardano/src/block/verify_chain.rs#L12) function for new blocks.
- Make an option to get raw binary data (cbor) by passing the respective content-type header