### PR TITLE
[IOHKCRB-19] Keep chain state in memory for utxos endpoint

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -14,14 +14,13 @@ extern crate cardano;
 extern crate cardano_storage;
 extern crate exe_common;
 
-use std::path::{
-    PathBuf,
-    Path,
-};
+use std::path::{Path, PathBuf};
 
 mod config;
 mod handlers;
 mod service;
+
+mod shared_chain_state;
 
 use self::config::{hermes_path, Config};
 use exe_common::config::net;
@@ -65,7 +64,7 @@ fn main() {
                         .help("either 'mainnet' or 'testnet'; may be given multiple times")
                         .required(false)
                         .multiple(true)
-                        .default_value("mainnet")
+                        .default_value("mainnet"),
                 )
                 .arg(
                     Arg::with_name("no-sync")
@@ -99,7 +98,7 @@ fn main() {
                     "mainnet" => net::Config::mainnet(),
                     "staging" => net::Config::staging(),
                     "testnet" => net::Config::testnet(),
-                    filepath  => {
+                    filepath => {
                         let path = Path::new(filepath);
                         match net::Config::from_file(path) {
                             None => panic!("unknown or missing template '{}'", template),

--- a/src/service.rs
+++ b/src/service.rs
@@ -27,6 +27,7 @@ pub fn start(cfg: Config) {
     } else {
         None
     };
+
     let _server = start_http_server(&cfg, networks);
 
     // XXX: consider installing a signal handler to initiate a graceful shutdown here
@@ -80,12 +81,37 @@ fn refresh_network(label: &str, net: &mut Network) {
         genesisdata::parse::parse(genesis_data.as_bytes())
     };
 
-    sync::net_sync(
+    let (tx, rx) = channel::<shared_chain_state::Event>();
+
+    shared_chain_state::start_update_thread(net.shared_chain_state.clone(), rx);
+
+    net_sync(
         &mut sync::get_peer(&label, &net_cfg, true),
         &net_cfg,
         &genesis_data,
         net.storage.clone(),
-        false,
+        tx,
     )
     .unwrap_or_else(|err| warn!("Sync failed: {:?}", err));
+}
+
+fn net_sync(
+    net: &mut Peer,
+    net_cfg: &net::Config,
+    genesis_data: &GenesisData,
+    storage: Arc<RwLock<Storage>>,
+    tx: Sender<shared_chain_state::Event>,
+) -> Result<(), exe_common::network::error::Error> {
+    let mut tip_header = net.get_tip()?;
+
+    loop {
+        sync::net_sync(net, &net_cfg, &genesis_data, storage.clone(), true)?;
+
+        match tx.send(shared_chain_state::Event::NewTip) {
+            Ok(_) => (),
+            Err(_) => warn!("There is no receiver for the NewTip message"),
+        }
+
+        tip_header = net.wait_for_new_tip(&tip_header.compute_hash())?;
+    }
 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -4,9 +4,18 @@ use exe_common::config::net;
 use exe_common::{genesisdata, sync};
 use iron;
 use router::Router;
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 use std::thread;
 use std::time::Duration;
+
+use std::sync::mpsc::{channel, Sender};
+
+use cardano::config::GenesisData;
+use cardano_storage::Storage;
+use exe_common::network::Api;
+use exe_common::network::Peer;
+
+use super::shared_chain_state;
 
 pub fn start(cfg: Config) {
     let networks = Arc::new(match cfg.get_networks() {

--- a/src/shared_chain_state.rs
+++ b/src/shared_chain_state.rs
@@ -1,0 +1,132 @@
+use cardano::block::chain_state::ChainState;
+use cardano::block::{Block, HeaderHash};
+use cardano_storage::chain_state::restore_chain_state;
+use cardano_storage::{self, Storage};
+use exe_common::config::net::Config;
+use exe_common::genesisdata;
+use std::sync::mpsc::Receiver;
+use std::{sync::Arc, sync::RwLock, thread};
+
+pub fn start_update_thread(shared_chain_state: Arc<SharedChainState>, events: Receiver<Event>) {
+    let chain_state = shared_chain_state.clone();
+    thread::spawn(move || loop {
+        let event = match events.recv() {
+            Ok(msg) => msg,
+            Err(_) => {
+                error!("The network refresher hung up");
+                break;
+            }
+        };
+        match event {
+            Event::NewTip => match chain_state.update() {
+                Ok(_) => (),
+                Err(err) => warn!("{}", err),
+            },
+        };
+    });
+}
+
+pub struct SharedChainState {
+    chain_state: RwLock<Arc<ChainState>>,
+    storage: Arc<RwLock<Storage>>,
+}
+
+pub enum Event {
+    NewTip,
+}
+
+impl SharedChainState {
+    pub fn from_storage(
+        storage: Arc<RwLock<Storage>>,
+        net: &Config,
+    ) -> Result<Self, cardano_storage::Error> {
+        info!("Recovering chain_state from storage");
+        let chain_state = {
+            let storage = storage.read().unwrap();
+            let blockid = Self::get_head(&*storage)?;
+
+            let genesis_str = genesisdata::data::get_genesis_data(&net.genesis_prev).unwrap();
+            let genesis_data = genesisdata::parse::parse(genesis_str.as_bytes());
+
+            restore_chain_state(&storage, &genesis_data, &blockid).unwrap()
+        };
+        Ok(Self {
+            chain_state: RwLock::new(Arc::new(chain_state)),
+            storage: storage,
+        })
+    }
+
+    pub fn read(&self) -> Arc<ChainState> {
+        let rguard = self.chain_state.read().unwrap();
+        Arc::clone(&*rguard)
+    }
+
+    fn update(&self) -> Result<(), &'static str> {
+        let storage = self.storage.read().unwrap();
+
+        let blockid = match Self::get_head(&*storage) {
+            Ok(hash) => hash,
+            Err(_) => return Err("Couldn't read the head"),
+        };
+
+        let new_state = {
+            let chain_state = self.chain_state.read().unwrap();
+            if chain_state.last_block != blockid {
+                match Self::update_from_memory(&chain_state, &blockid, &storage) {
+                    Ok(new_chain_state) => Some(new_chain_state),
+                    Err(_) => return Err("Verification error"),
+                }
+            } else {
+                None
+            }
+        };
+
+        //Only take the write lock for the update part
+        if let Some(chain_state) = new_state {
+            info!("Applying updates to the ChainState");
+            let mut write_guard = self.chain_state.write().unwrap();
+            *write_guard = Arc::new(chain_state);
+        }
+        Ok(())
+    }
+
+    fn update_from_memory(
+        current_state: &ChainState,
+        current: &cardano::block::HeaderHash,
+        storage: &Storage,
+    ) -> Result<ChainState, cardano::block::verify::Error> {
+        let mut blocks_to_apply = vec![];
+        let mut cursor = current.clone();
+
+        //Find all the new blocks
+        while cursor != current_state.last_block {
+            let block = Self::read_block(&cursor, storage).unwrap();
+            let previous = block.header().previous_header();
+            //I'm not sure if I should store the block or only the hashes
+            blocks_to_apply.push(block);
+            cursor = previous;
+        }
+
+        let mut chain_state = current_state.clone();
+
+        for block in blocks_to_apply.iter().rev() {
+            let hash = block.header().compute_hash();
+            chain_state.verify_block(&hash, &block)?;
+        }
+        Ok(chain_state)
+    }
+
+    fn read_block(
+        blockid: &cardano::block::HeaderHash,
+        storage: &Storage,
+    ) -> Result<Block, cardano_storage::Error> {
+        let blockhash = cardano_storage::types::header_to_blockhash(blockid);
+        Ok(storage.read_block(&blockhash)?.decode()?)
+    }
+
+    fn get_head(storage: &Storage) -> Result<HeaderHash, cardano_storage::Error> {
+        storage
+            .get_block_from_tag(&cardano_storage::tag::HEAD)
+            .and_then(|block| Ok(block.header().compute_hash()))
+    }
+}

--- a/src/shared_chain_state.rs
+++ b/src/shared_chain_state.rs
@@ -100,9 +100,11 @@ impl SharedChainState {
 
         //Find all the new blocks
         while cursor != current_state.last_block {
+            //I'm not sure there is something to do on this error
             let block = Self::read_block(&cursor, storage).unwrap();
             let previous = block.header().previous_header();
-            //I'm not sure if I should store the block or only the hashes
+            // As this should be called frequently,
+            // I don't think storing the blocks should be a problem memorywise
             blocks_to_apply.push(block);
             cursor = previous;
         }


### PR DESCRIPTION
# Keep the ChainState in memory to retrieve the utxos fast

## Summary
- Add shared_chain_state module to encapsulate the functionality.
- Keep a SharedChainState in the Network object that's passed to every endpoint.
- The chain state is initially restored from disk with the `restore_chain_state` on the server startup, then a separate thread is launched to keep the data up to date on every new tip (notified by a channel).
- Modify the net_sync function so that it sends an event on each new block.